### PR TITLE
support for authorization over CORS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jackpine/rack-permissive-cors.git
-  revision: 83cf32550c5c7f6583c07ef02e3a7ec9abcda767
+  revision: 73c880962ed57602aca4ccbcdbf1673d91e74c66
   specs:
     rack-permissive-cors (0.1.0)
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,7 +2,7 @@ class Api::BaseController < ApplicationController
 
   # Don't do regular CSRF protection over the json API, rather just ignore the entire session
   protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format == 'application/json' }
-  before_filter :authenticate_user_from_token!
+  before_filter :authenticate_user_from_token!, except: ['handle_options_request']
 
   def default_url_options
     { :host => Rails.application.config.default_host }
@@ -13,6 +13,12 @@ class Api::BaseController < ApplicationController
       render json: { error: { message: "Could not authenticate you", code: 32 } },
              status: 401
     end
+  end
+
+  # These are made by some HTTP Clients wrt CORS. In particular, Ember will make
+  # an OPTIONS preflight request when talking to a different domain.
+  def handle_options_request
+    head(:ok) if request.request_method == "OPTIONS"
   end
 
   def authenticated_from_token?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   namespace 'api' do
+    match '*any_options_path', to: 'base#handle_options_request', via: :options
     namespace 'v1' do
       resources :api_keys, only: [:create], defaults: { format: :json }
-
       resources :games, only: [:show, :index], defaults: { format: :json } do
         member do
           get :current_spot


### PR DESCRIPTION
CORS requires that you whitelist the headers being sent across origins - so now that the API requires an authentication header, we have to whitelist that header in our CORS configuration.
